### PR TITLE
Fix pkg-config generation CMake variables

### DIFF
--- a/gdtoa-desktop.pc.cmake
+++ b/gdtoa-desktop.pc.cmake
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: gdtoa-desktop
 Description: Binary↔decimal floating-point conversion library


### PR DESCRIPTION
`CMAKE_INSTALL_LIBDIR` may already include a prefix, so

    libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@

with a `CMAKE_INSTALL_PREFIX` of `/usr` and a `CMAKE_INSTALL_LIBDIR` of `/usr/lib` can result in

    libdir=/usr//usr/lib

which is obviously incorrect.

To remedy this, CMake provides `CMAKE_INSTALL_FULL_*` variants, which are guaranteed absolute by prepending the `CMAKE_INSTALL_PREFIX` only when necessary. So our last example's source would now be

    libdir=@CMAKE_INSTALL_FULL_LIBDIR

which would produce

    libdir=/usr/lib

as it should.

With a `CMAKE_INSTALL_PREFIX` of `/usr` and a `CMAKE_INSTALL_LIBDIR` of `lib`

    libdir=/usr/lib

prepending happens properly, as we force now.

With a `CMAKE_INSTALL_PREFIX` of `/opt/gdtoa-desktop` and a `CMAKE_INSTALL_LIBDIR` of `/usr/lib`

    libdir=/usr/lib

no confusion happens, and the prefix is not incorrectly prepended.

This fixes the generated pkg-config file at least in Nixpkgs, which absolutely specifies the `CMAKE_INSTALL_LIBDIR` to CMake.